### PR TITLE
Add internal heading links, use to make clear what eligibility requirements refer to

### DIFF
--- a/_includes/en/submission-form.html
+++ b/_includes/en/submission-form.html
@@ -1,11 +1,11 @@
-<h3>How Do I Apply to the Fellowship?</h3>
+<h3 id="how-do-i-apply-to-the-fellowship">How Do I Apply to the Fellowship?</h3>
 
 <p>Interested applicants should submit the following materials to <strong><a href="mailto:fellowships@creativecommons.org">fellowships@creativecommons.org</a></strong> with <strong>“Bassel Khartabil Free Culture Fellowship application”</strong> in the subject line:</p>
 
 <ul>
 	<li>A vision statement, which should address the following:</li>
 	<ul>
-		<li>Your alignment with the eligibility requirements.</li>
+		<li>Your alignment with the <a ref="#who-shoulda-apply"eligibility requirements</a>.</li>
 		<li>Details regarding your proposed initiative or project, including anticipated impacts, goals, and outcomes.</li>
 		<li>Your record of open community contribution and collaboration.</li>
 	</ul>

--- a/_includes/en/submission-form.html
+++ b/_includes/en/submission-form.html
@@ -5,7 +5,7 @@
 <ul>
 	<li>A vision statement, which should address the following:</li>
 	<ul>
-		<li>Your alignment with the <a ref="#who-shoulda-apply"eligibility requirements</a>.</li>
+		<li>Your alignment with the <a ref="#who-should-apply"eligibility requirements</a>.</li>
 		<li>Details regarding your proposed initiative or project, including anticipated impacts, goals, and outcomes.</li>
 		<li>Your record of open community contribution and collaboration.</li>
 	</ul>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ direction: ltr
 <p>This unique and life-changing fellowship promotes the values important to Bassel&#8217;s work and life: open culture, radical sharing, free knowledge, remix, collaboration, courage, optimism, and humanity.</p>
 <p>Fellows are expected to lead projects or initiatives that will catalyze free culture, particularly in societies vulnerable to attacks on freedom of expression and free access to knowledge. Special consideration will be given to applicants operating within closed societies, under adverse circumstances, and in developing economies where other forms of support are scarce.</p>
 
-<h3>What are the Fellowship Benefits?</h3>
+<h3 id="what-are-the-fellowship-benefits">What are the Fellowship Benefits?</h3>
 
 <p>Fellowships are based on <strong>one-year terms, which are eligible for renewal. </strong></p>
 <ul>
@@ -18,7 +18,7 @@ direction: ltr
 </ul>
 <p>The Fellowship is intended to allow participants to independently locate wherever they can deliver the most impact for their initiative.</p>
 
-<h3>Who Should Apply?</h3>
+<h3 id="who-should-apply">Who Should Apply?</h3>
 
 <p>The Fellowship is open to individuals and small teams worldwide, who:</p>
 <ul>


### PR DESCRIPTION
Referring to eligibility requirements without being clear about where they are is a deterrent to potential applicants.